### PR TITLE
Reset recurring task completion state per schedule instead of everyday

### DIFF
--- a/src/documentActions.ts
+++ b/src/documentActions.ts
@@ -320,8 +320,9 @@ export async function revealTask(lineNumber: number, document?: TextDocument) {
 	}, 700);
 }
 /**
- * Recurring tasks completion state should reset every day.
- * This function goes through all tasks in a document and resets their completion/count, adds `{overdue}` tag when needed
+ * Recurring tasks completion state should reset according to schedule.
+ * This function goes through all recurring tasks in a document, resets their
+ * completion/count, and adds `{overdue}` tag when needed.
  */
 export async function resetAllRecurringTasks(document: TextDocument, lastVisit: Date | string = new Date()) {
 	if (typeof lastVisit === 'string') {
@@ -333,35 +334,47 @@ export async function resetAllRecurringTasks(document: TextDocument, lastVisit: 
 	const nowWithoutTime = dateWithoutTime(now);
 
 	for (const task of tasks) {
-		if (task.due?.isRecurring) {
-			const line = document.lineAt(task.lineNumber);
-			if (task.done) {
-				removeCompletionDateWorkspaceEdit(edit, document, task);
-				removeStartWorkspaceEdit(edit, document, task);
-				removeDurationWorkspaceEdit(edit, document, task);
-			} else {
-				if (!task.overdue && !dayjs().isSame(lastVisit, 'day')) {
-					const lastVisitWithoutTime = dateWithoutTime(lastVisit);
-					const daysSinceLastVisit = dayjs(nowWithoutTime).diff(lastVisitWithoutTime, 'day');
-					for (let i = daysSinceLastVisit; i > 0; i--) {
-						const date = dayjs().subtract(i, 'day');
-						const res = new DueDate(task.due.raw, {
-							targetDate: date.toDate(),
-						});
-						if (res.isDue === IsDue.Due || res.isDue === IsDue.Overdue) {
-							if (!task.noOverdue) {
-								addOverdueSpecialTagWorkspaceEdit(edit, document, line, date.format(DATE_FORMAT));
-							}
-							break;
-						}
-					}
-				}
+		if (!task.due?.isRecurring) {
+			continue;
+		}
+
+		let overdueDate;
+		const lastVisitWithoutTime = dateWithoutTime(lastVisit);
+		const daysSinceLastVisit = dayjs(nowWithoutTime).diff(lastVisitWithoutTime, 'day');
+		for (let i = daysSinceLastVisit; i > 0; i--) {
+			const date = dayjs().subtract(i, 'day');
+			const res = new DueDate(task.due.raw, {
+				targetDate: date.toDate(),
+			});
+			if (res.isDue === IsDue.Due || res.isDue === IsDue.Overdue) {
+				overdueDate = date;
+				break;
 			}
+		}
+		
+		// Task is not overdue yet.
+		// If the task is not done, it can still be completed before due date.
+		// If the task is done, then there is still time before it needs to recur.
+		// Either way, nothing to reset.
+		if (overdueDate === undefined) {
+			return;
+		}
+
+		if (task.done) {
+			// Task is done and it's time for the next iteration per recurrent schedule.
+			// Reset completion state.
+			removeCompletionDateWorkspaceEdit(edit, document, task);
+			removeStartWorkspaceEdit(edit, document, task);
+			removeDurationWorkspaceEdit(edit, document, task);
 
 			const count = task.count;
 			if (count) {
 				setCountCurrentValueWorkspaceEdit(edit, document.uri, count, '0');
 			}
+		} else if (!task.overdue && !task.noOverdue) {
+			// Task is not done and overdue. Mark as such without resetting any count.
+			const line = document.lineAt(task.lineNumber);
+			addOverdueSpecialTagWorkspaceEdit(edit, document, line, overdueDate.format(DATE_FORMAT));
 		}
 	}
 	return applyEdit(edit, document);


### PR DESCRIPTION
Fixes #74 to only reset count / completion state for recurrent tasks when they are done and it's time for the next iteration per the recurrent schedule. 

I've tested all combinations manually, but if there's a place where I can add unit tests or if I there are specific steps I should follow to test thoroughly, happy to do so!

Thank you!