### PR TITLE
Make sorting respect nested tasks

### DIFF
--- a/src/TheTask.ts
+++ b/src/TheTask.ts
@@ -232,4 +232,15 @@ export class TheTask {
 	}
 
 	static defaultTaskPriority: Priority = 'G';
+	
+	/**
+	 * @returns Raw text lines corresponding to the task and all nested tasks recursively.
+	 */
+	rawTextWithNestedTasks(): string {
+		const rawTextLines = [this.rawText];
+		for (const subtask of this.subtasks) {
+			rawTextLines.push(subtask.rawTextWithNestedTasks());
+		}
+		return rawTextLines.join('\n');
+	}
 }

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -121,6 +121,13 @@ export function sortTasks(tasks: TheTask[], sortProperty: SortProperty, directio
 	if (direction === SortDirection.ASC) {
 		return sortedTasks.reverse();
 	}
+	
+	// Recursively sort nested tasks
+	for (const task of sortedTasks) {
+		if (task.subtasks.length) {
+			task.subtasks = sortTasks(task.subtasks, sortProperty, direction);
+		}
+	}
 
 	return sortedTasks;
 }


### PR DESCRIPTION
Fix for https://github.com/usernamehw/vscode-todo-md/issues/25

**Tested with the following example:**
```
(C) task 1
  (B) subtask 1a
  (A) subtask 1b
(C) task 2 {due:2023-08-30}
  (B) subtask 2a {due:2023-08-20}
  subtask 2b {due:2023-08-10}
  (A) subtask 2c
(A) task 3
(A) task 4 {due:2023-08-05}
  (B) subtask 4a
  (C) subtask 4b
```

Default sort output **before** with nesting broken:
```
(A) task 4 {due:2023-08-05}
  subtask 2b {due:2023-08-10}
  (B) subtask 2a {due:2023-08-20}
(C) task 2 {due:2023-08-30}
  (A) subtask 1b
  (A) subtask 2c
(A) task 3
  (B) subtask 1a
  (B) subtask 4a
(C) task 1
  (C) subtask 4b
```

Defaults sort output **after** with tree structure maintained and subtasks sorted among themselves:
```
(A) task 4 {due:2023-08-05}
  (B) subtask 4a
  (C) subtask 4b
(C) task 2 {due:2023-08-30}
  subtask 2b {due:2023-08-10}
  (B) subtask 2a {due:2023-08-20}
  (A) subtask 2c
(A) task 3
(C) task 1
  (A) subtask 1b
  (B) subtask 1a
```